### PR TITLE
add access control header to avoid CORS issue

### DIFF
--- a/authhelper.go
+++ b/authhelper.go
@@ -137,6 +137,7 @@ func (c Claims) Valid() error {
 }
 
 func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout io.Writer, path string) bool {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
 	defer r.Body.Close()
 	if r.Method != "POST" {
 		http.Error(w, "POST expected", 400)


### PR DESCRIPTION
Small change to add the `Access-Control-Allow-Origin` header.  If I want to be able to check the status code on the auth helper frontend page, I am unable to use the `no-cors` mode on `fetch` ([context](https://stackoverflow.com/questions/43262121/trying-to-use-fetch-and-pass-in-mode-no-cors)).

This will allow FE to check explicitly for a 204 status code to ensure the token was successfully sent.

Let me know if there is anything else needed for this PR