### PR TITLE
Handle OPTIONS request

### DIFF
--- a/authhelper.go
+++ b/authhelper.go
@@ -64,6 +64,13 @@ func main2(stdout io.Writer, config configData) {
 	// Using httptest since it takes care of picking a random port
 	var svr *httptest.Server
 	svr = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// Special case for the OPTIONS request. Just return the Allow header with POST.
+		if r.Method == http.MethodOptions {
+			w.Header().Set("Allow", http.MethodPost)
+			return
+		}
+
 		done := handle(w, r, svr, stdout, path, config)
 		if done || !config.HangAround {
 			wg.Done()

--- a/authhelper_test.go
+++ b/authhelper_test.go
@@ -246,6 +246,18 @@ func fakeBrowser(t *testing.T, us string, claims jwt.MapClaims, httpError int) e
 	}
 
 	t.Logf("POST token to %s", returnTo)
+	optionsRequest, err := http.NewRequest(http.MethodOptions, returnTo, strings.NewReader(""))
+	if err != nil {
+		return fmt.Errorf("OPTIONS NewRequest %s error: %w", returnTo, err)
+	}
+	optionsResponse, err := http.DefaultClient.Do(optionsRequest)
+	if err != nil {
+		return fmt.Errorf("OPTIONS response to %s error: %w", returnTo, err)
+	}
+	allow := optionsResponse.Header.Get("Allow")
+	if allow != http.MethodPost {
+		return fmt.Errorf("invalid OPTIONS response to %s: %s", returnTo, allow)
+	}
 	resp, err := http.Post(returnTo, "text/plain", strings.NewReader(tokenString))
 	if err != nil {
 		return fmt.Errorf("POST to %s error: %w", returnTo, err)


### PR DESCRIPTION
On my local Chrome instance (Version 104.0.5112.101 (Official Build) (64-bit)), the HTTP POST request was preceded by an HTTP OPTIONS request, which caused the authhelper to fail (unless using the --hand-around flag). Now an OPTIONS request is intercepted and responded to with an Allow header set to "POST".

Unit test updated.