### PR TITLE
Improve error handling; add timeout, env-name, env-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@ singlestore -u $EMAIL_ADDRESS -h $CLUSTER_HOSTNAME -P $CLUSTER_PORT --password=`
 ```
 
 Note: the Safari browser is not compatible with the `singlestore-auth-helper` because it lacks a cross-site-scripting exception for localhost.
+
+To set the results of the auth-helper in environment variables for use in scripting, use the `env-name` and `env-status` command line options. When these are used, the status and token are prefixed with the given name, such as:
+
+```sh
+authhelper --env-status=STATUS --env-name=TOKEN
+
+STATUS=0
+TOKEN=eyJhbGcibW9zc0BzaW5nbGVzdG9yZS5jb20iLCJhdWQiOlsiZW5naW5lIiwiIXBvcnRhbCJdLCJleHAiOjE
+```
+
+The output can be evaluated, thus setting the environment variables:
+
+```shell
+eval $(authhelper --env-status=STATUS --env-name=TOKEN)
+
+echo $TOKEN
+eyJhbGcibW9zc0BzaW5nbGVzdG9yZS5jb20iLCJhdWQiOlsiZW5naW5lIiwiIXBvcnRhbCJdLCJleHAiOjE
+```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note: the Safari browser is not compatible with the `singlestore-auth-helper` be
 To set the results of the auth-helper in environment variables for use in scripting, use the `env-name` and `env-status` command line options. When these are used, the status and token are prefixed with the given name, such as:
 
 ```sh
-authhelper --env-status=STATUS --env-name=TOKEN
+singlestore-auth-helper --env-status=STATUS --env-name=TOKEN
 
 STATUS=0
 TOKEN=eyJhbGcibW9zc0BzaW5nbGVzdG9yZS5jb20iLCJhdWQiOlsiZW5naW5lIiwiIXBvcnRhbCJdLCJleHAiOjE
@@ -41,7 +41,7 @@ TOKEN=eyJhbGcibW9zc0BzaW5nbGVzdG9yZS5jb20iLCJhdWQiOlsiZW5naW5lIiwiIXBvcnRhbCJdLC
 The output can be evaluated, thus setting the environment variables:
 
 ```shell
-eval $(authhelper --env-status=STATUS --env-name=TOKEN)
+eval $(singlestore-auth-helper --env-status=STATUS --env-name=TOKEN)
 
 echo $TOKEN
 eyJhbGcibW9zc0BzaW5nbGVzdG9yZS5jb20iLCJhdWQiOlsiZW5naW5lIiwiIXBvcnRhbCJdLCJleHAiOjE

--- a/authhelper.go
+++ b/authhelper.go
@@ -76,7 +76,7 @@ func main2(stdout io.Writer, config configData) {
 	// Using httptest since it takes care of picking a random port
 	var svr *httptest.Server
 	svr = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Printf("handle %v %v\n", r.Method, r.URL.String())
+
 		// Special case for the OPTIONS request. Just return the Allow header with POST.
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Allow", http.MethodPost)

--- a/authhelper.go
+++ b/authhelper.go
@@ -86,7 +86,7 @@ func main2(stdout io.Writer, config configData) {
 		done, status := handle(w, r, svr, stdout, path, config)
 		if done || !config.HangAround {
 			if config.EnvStatus != "" {
-				fmt.Fprintln(stdout, fmt.Sprintf("%s=%v", config.EnvStatus, status))
+				fmt.Fprintf(stdout, "%s=%v\n", config.EnvStatus, status)
 			}
 			wg.Done()
 		}
@@ -112,7 +112,7 @@ func main2(stdout io.Writer, config configData) {
 	err := browser.OpenURL(url)
 	if err != nil {
 		if config.EnvStatus != "" {
-			fmt.Fprintln(stdout, fmt.Sprintf("%s=1", config.EnvStatus))
+			fmt.Fprintf(stdout, "%s=1\n", config.EnvStatus)
 		}
 		fatal(err.Error(), config.EnvStatus)
 	}

--- a/authhelper.go
+++ b/authhelper.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -77,7 +76,7 @@ func main2(stdout io.Writer, config configData) {
 	// Using httptest since it takes care of picking a random port
 	var svr *httptest.Server
 	svr = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
+		fmt.Printf("handle %v %v\n", r.Method, r.URL.String())
 		// Special case for the OPTIONS request. Just return the Allow header with POST.
 		if r.Method == http.MethodOptions {
 			w.Header().Set("Allow", http.MethodPost)
@@ -111,7 +110,6 @@ func main2(stdout io.Writer, config configData) {
 	}
 	url := config.BaseURL + "?" + values.Encode()
 	err := browser.OpenURL(url)
-	err = errors.New("foo")
 	if err != nil {
 		if config.EnvStatus != "" {
 			fmt.Fprintln(stdout, fmt.Sprintf("%s=1", config.EnvStatus))

--- a/authhelper.go
+++ b/authhelper.go
@@ -32,15 +32,15 @@ func main() {
 }
 
 type configData struct {
-	BaseURL       string   `flag:"baseURL" default:"https://portal.singlestore.com/engine-sso" help:"override the URL passed to the browser"`
-	Email         string   `flag:"email e" validate:"omitempty,validate" help:"users SSO email address, if known"`
+	BaseURL       string   `flag:"baseURL" validate:"url" default:"https://portal.singlestore.com/engine-sso" help:"override the URL passed to the browser"`
+	Email         string   `flag:"email e" validate:"omitempty,email" help:"users SSO email address, if known"`
 	ClusterID     []string `flag:"cluster-id,split=comma" help:"comma-separated list of specific clusters to access"`
 	Databases     []string `flag:"databases,split=comma" help:"comma-separated list of specific databases to access"`
 	OutputFormat  string   `flag:"output o" validate:"oneof=jwt json" default:"jwt" help:"output format (jwt, json)"`
 	HangAround    bool     `flag:"hang-around" help:"keep listening even if an invalid request was made"`
-	Timeout       string   `flag:"timeout" validate:"omitempty" help:"time duration before timing out, such as 30s"`
-	EnvName       string   `flag:"env-name" validate:"omitempty" help:"the name of the environment variable to receive the token"`
-	EnvStatus     string   `flag:"env-status" validate:"omitempty" help:"the name of the environment variable to receive the exit status"`
+	Timeout       string   `flag:"timeout" help:"time duration before timing out, such as 30s"`
+	EnvName       string   `flag:"env-name" help:"the name of the environment variable to receive the token"`
+	EnvStatus     string   `flag:"env-status" help:"the name of the environment variable to receive the exit status"`
 	Debug         bool     `flag:"debug d" help:"print the recevied claims"`
 	parsedTimeout time.Duration
 }
@@ -176,7 +176,7 @@ func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout
 	}
 	raw, err := io.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Bad read from request: %s", err)
+		log.Printf("Bad read from request: %s\n", err)
 		http.Error(w, "bad read", 500)
 		return false, 1
 	}
@@ -184,7 +184,7 @@ func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout
 	var claims Claims
 	_, _, err = jwtParser.ParseUnverified(string(raw), &claims)
 	if err != nil {
-		log.Printf("Could not parse claims: %s", err)
+		log.Printf("Could not parse claims: %s\n", err)
 		http.Error(w, "could not parse claims: "+err.Error(), 400)
 		return false, 1
 	}
@@ -196,7 +196,7 @@ func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout
 		}
 	}
 	if err := claims.Valid(); err != nil {
-		log.Printf("Could not parse claims: %s", err)
+		log.Printf("Could not parse claims: %s\n", err)
 		http.Error(w, "could not parse claims: "+err.Error(), 400)
 		return false, 1
 	}
@@ -225,7 +225,7 @@ func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout
 		}
 		enc, err := json.Marshal(output)
 		if err != nil {
-			log.Printf("Could not marshal output: %s", err)
+			log.Printf("Could not marshal output: %s\n", err)
 			http.Error(w, "could not marshal output "+err.Error(), 500)
 			return false, 1
 		}
@@ -239,7 +239,7 @@ func handle(w http.ResponseWriter, r *http.Request, svr *httptest.Server, stdout
 
 func fatal(msg string, envStatus string) {
 	if envStatus != "" {
-		log.Printf("%s=1", envStatus)
+		log.Printf("%s=1\n", envStatus)
 	}
 	log.Fatal(msg)
 }


### PR DESCRIPTION
- Improve error handling. Instead of panicking on errors, instead call log.Fatal which will log (print) the error and call os.Exit(1)
- Add the --timeout command line option which takes a duration, such as "30s" or "1m". If this duration expires, an error is raised.
- Add the --env-name command line option. If set, the output token will be prefixed with this name (i.e. TOKEN=<token>). This can be used in a scripting environment to set an environmental variable using eval (i.e. eval $(command)).
- Add the -env-status command line option. If set, the exit status will be set with this name (i.e. STATUS=0).